### PR TITLE
Embarrassing wrong tag name on `peerDependencies`.

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/patriciogonzalezvivo/glsl-pipeline#readme",
   "peerDependencies": {
-    "@react-three/fiber": ">=^8.15.11",
+    "@react-three/fiber": ">=8.15.11",
     "react": ">=18.2.0",
     "three": ">=0.158"
   },


### PR DESCRIPTION
This throws an error like this when running `npm install glsl-pipeline --save`:
```bash
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name ">=^8.15.11" of package "@react-three/fiber@>=^8.15.11": Tags may not have any characters that encodeURIComponent encodes
```
I hope this pull request fixes the error. You may have to do a patch publish on this. I'm so sorry for this overlooked mistake.